### PR TITLE
refactor lightcon connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- redundant connections with lightcon motors removed
+
 ## [2022.11.0]
 
 ### Added

--- a/yaqd_lightcon/_aiohttp.py
+++ b/yaqd_lightcon/_aiohttp.py
@@ -6,9 +6,6 @@ import asyncio
 
 class TaskSet(set):
     """container class for tasks to keep strong references"""
-    def __init__(self, iterable=()) -> set[asyncio.Task]:
-        super().__init__(iterable)
-
     def add(self, task: asyncio.Task):
         super().add(task)
         task.add_done_callback(self.discard)

--- a/yaqd_lightcon/_aiohttp.py
+++ b/yaqd_lightcon/_aiohttp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import aiohttp  # type: ignore
 import asyncio
 

--- a/yaqd_lightcon/_aiohttp.py
+++ b/yaqd_lightcon/_aiohttp.py
@@ -7,9 +7,6 @@ import asyncio
 class TaskSet(set):
     """container class for tasks to keep strong references"""
 
-    def __init__(self, iterable=()) -> set[asyncio.Task]:
-        super().__init__(iterable)
-
     def add(self, task: asyncio.Task):
         super().add(task)
         task.add_done_callback(self.discard)

--- a/yaqd_lightcon/_aiohttp.py
+++ b/yaqd_lightcon/_aiohttp.py
@@ -4,8 +4,10 @@ import aiohttp  # type: ignore
 import asyncio
 
 
-class TaskSet(set[asyncio.Task]):
+class TaskSet(set):
     """container class for tasks to keep strong references"""
+    def __init__(self, iterable=()) -> set[asyncio.Task]:
+        super().__init__(iterable)
 
     def add(self, task: asyncio.Task):
         super().add(task)

--- a/yaqd_lightcon/_aiohttp.py
+++ b/yaqd_lightcon/_aiohttp.py
@@ -1,17 +1,18 @@
+from __future__ import annotations
+
 import aiohttp  # type: ignore
 import asyncio
 
-from typing import Coroutine
 
 
-class TaskSet(set):
+class TaskSet(set[asyncio.Task]):
     """container class for tasks to keep strong references"""
 
     def add(self, task: asyncio.Task):
         super().add(task)
         task.add_done_callback(self.discard)
 
-    def add_coro(self, coro: Coroutine):
+    def add_coro(self, coro):
         """create task and add to running loop"""
         task = asyncio.get_running_loop().create_task(coro)
         self.add(task)
@@ -19,8 +20,7 @@ class TaskSet(set):
 
 class Client:
     """a single client for all daemons sessions"""
-
-    daemons = set()  # keep track of connected daemons
+    daemons:set[int] = set()  # keep track of connected daemons
     session = None  # to be initialized
     tasks = TaskSet()
 

--- a/yaqd_lightcon/_aiohttp.py
+++ b/yaqd_lightcon/_aiohttp.py
@@ -6,6 +6,7 @@ import asyncio
 
 class TaskSet(set):
     """container class for tasks to keep strong references"""
+
     def __init__(self, iterable=()) -> set[asyncio.Task]:
         super().__init__(iterable)
 

--- a/yaqd_lightcon/_aiohttp.py
+++ b/yaqd_lightcon/_aiohttp.py
@@ -8,27 +8,32 @@ class TaskSet(set):
         super().add(task)
         task.add_done_callback(self.discard)
 
+    def add_coro(self, coro:asyncio._CoroutineLike):
+        """create task and add to running loop"""
+        task = asyncio.get_running_loop().create_task(coro)
+        self.add(task)
+
 
 class Client:
-    """a single client session for all daemons"""
+    """a single client for all daemons sessions"""
     daemons = set()  # keep track of connected daemons
     session = None  # to be initialized
     tasks = TaskSet()
 
     def open(cls, daemon_id):
+        """initializes a new client if one isn't open"""
         cls.daemons.add(daemon_id)
-        if cls.session is None:
+        if cls.session is None or (cls.session.closed):
             cls.session = aiohttp.ClientSession()
 
     def close(cls, daemon_id):
-        """close session only if there are no daemons still running off of it"""
+        """close session if there are no daemons still connected"""
         cls.daemons.discard(daemon_id)
         if not cls.daemons:
-            cls.tasks.add(asyncio.get_running_loop().create_task(cls.close()))
+            cls.tasks.add_coro(cls.close())
 
     async def close(cls) -> None:
         if (cls.session is not None) and (not cls.session.closed):
-            await cls.session.close()
-            cls.session = None
+            await cls.session.__aexit__()
 
 

--- a/yaqd_lightcon/_aiohttp.py
+++ b/yaqd_lightcon/_aiohttp.py
@@ -1,20 +1,7 @@
-from __future__ import annotations
-
 import aiohttp  # type: ignore
 import asyncio
 
-
-class TaskSet(set):
-    """container class for tasks to keep strong references"""
-
-    def add(self, task: asyncio.Task):
-        super().add(task)
-        task.add_done_callback(self.discard)
-
-    def add_coro(self, coro):
-        """create task and add to running loop"""
-        task = asyncio.get_running_loop().create_task(coro)
-        self.add(task)
+from ._taskset import TaskSet
 
 
 class Client:

--- a/yaqd_lightcon/_aiohttp.py
+++ b/yaqd_lightcon/_aiohttp.py
@@ -1,0 +1,34 @@
+import aiohttp  # type: ignore
+import asyncio
+
+
+class TaskSet(set):
+    """container class for tasks to keep strong references"""
+    def add(self, task:asyncio.Task):
+        super().add(task)
+        task.add_done_callback(self.discard)
+
+
+class Client:
+    """a single client session for all daemons"""
+    daemons = set()  # keep track of connected daemons
+    session = None  # to be initialized
+    tasks = TaskSet()
+
+    def open(cls, daemon_id):
+        cls.daemons.add(daemon_id)
+        if cls.session is None:
+            cls.session = aiohttp.ClientSession()
+
+    def close(cls, daemon_id):
+        """close session only if there are no daemons still running off of it"""
+        cls.daemons.discard(daemon_id)
+        if not cls.daemons:
+            cls.tasks.add(asyncio.get_running_loop().create_task(cls.close()))
+
+    async def close(cls) -> None:
+        if (cls.session is not None) and (not cls.session.closed):
+            await cls.session.close()
+            cls.session = None
+
+

--- a/yaqd_lightcon/_aiohttp.py
+++ b/yaqd_lightcon/_aiohttp.py
@@ -6,11 +6,12 @@ from typing import Coroutine
 
 class TaskSet(set):
     """container class for tasks to keep strong references"""
-    def add(self, task:asyncio.Task):
+
+    def add(self, task: asyncio.Task):
         super().add(task)
         task.add_done_callback(self.discard)
 
-    def add_coro(self, coro:Coroutine):
+    def add_coro(self, coro: Coroutine):
         """create task and add to running loop"""
         task = asyncio.get_running_loop().create_task(coro)
         self.add(task)
@@ -18,6 +19,7 @@ class TaskSet(set):
 
 class Client:
     """a single client for all daemons sessions"""
+
     daemons = set()  # keep track of connected daemons
     session = None  # to be initialized
     tasks = TaskSet()
@@ -40,5 +42,3 @@ class Client:
     async def _close(cls) -> None:
         if (cls.session is not None) and (not cls.session.closed):
             await cls.session.__aexit__()
-
-

--- a/yaqd_lightcon/_aiohttp.py
+++ b/yaqd_lightcon/_aiohttp.py
@@ -4,7 +4,6 @@ import aiohttp  # type: ignore
 import asyncio
 
 
-
 class TaskSet(set[asyncio.Task]):
     """container class for tasks to keep strong references"""
 
@@ -20,7 +19,8 @@ class TaskSet(set[asyncio.Task]):
 
 class Client:
     """a single client for all daemons sessions"""
-    daemons:set[int] = set()  # keep track of connected daemons
+
+    daemons: set[int] = set()  # keep track of connected daemons
     session = None  # to be initialized
     tasks = TaskSet()
 

--- a/yaqd_lightcon/_lightcon_topas4_motor.py
+++ b/yaqd_lightcon/_lightcon_topas4_motor.py
@@ -1,27 +1,36 @@
 import asyncio
 import pathlib
+import os
 from typing import Dict, Any, List
 
-import aiohttp  # type: ignore
 from yaqd_core import IsHomeable, IsDiscrete, HasLimits, HasPosition, IsDaemon
-
+from ._aiohttp import TaskSet, Client
 
 class LightconTopas4Motor(IsHomeable, IsDiscrete, HasLimits, HasPosition, IsDaemon):
     _kind = "lightcon-topas4-motor"
+    __sessions = {}
 
     def __init__(self, name: str, config: Dict[str, Any], config_filepath: pathlib.Path):
         super().__init__(name, config, config_filepath)
+        self.logger.info(f"PID: {os.getpid()}")
         self._base_url = f"http://{config['topas4_host']}:{config['topas4_port']}/{config['serial']}/v0/PublicApi"
         self._motor_index = config["motor_index"]
-        self._http_session = aiohttp.ClientSession()
+        self.client = Client
+        self.client.open(self.config["port"])
+        self._http_session = self.client.session
         self._position_identifiers: Dict[str, float] = {}
+        self.tasks = TaskSet()
 
     async def update_state(self):
         while True:
             async with self._http_session.get(
                 f"{self._base_url}/Motors?id={self._motor_index}"
             ) as resp:
-                json = await resp.json()
+                try:
+                    json = await resp.json()
+                except:
+                    self.logger.error(await resp.read())
+
                 self._state["position"] = json["ActualPositionInUnits"]
                 self._state["hw_limits"] = (
                     json["MinimalPositionInUnits"],
@@ -57,15 +66,22 @@ class LightconTopas4Motor(IsHomeable, IsDiscrete, HasLimits, HasPosition, IsDaem
 
     def _set_position(self, position):
         self._busy = True
-        self._loop.create_task(
-            self._http_session.put(
-                f"{self._base_url}/Motors/TargetPositionInUnits?id={self._motor_index}",
-                json=position,
+        self.tasks.add(
+            self._loop.create_task(
+                self._http_session.put(
+                    f"{self._base_url}/Motors/TargetPositionInUnits?id={self._motor_index}",
+                    json=position,
+                )
             )
         )
 
     def home(self):
         self._busy = True
-        self._loop.create_task(
-            self._http_session.post(f"{self._base_url}/Motors/Home?id={self._motor_index}")
+        self.tasks.add(
+            self._loop.create_task(
+                self._http_session.post(f"{self._base_url}/Motors/Home?id={self._motor_index}")
+            )
         )
+
+    def close(self):
+        self.client.close(self._config["port"])

--- a/yaqd_lightcon/_lightcon_topas4_motor.py
+++ b/yaqd_lightcon/_lightcon_topas4_motor.py
@@ -18,7 +18,7 @@ class LightconTopas4Motor(IsHomeable, IsDiscrete, HasLimits, HasPosition, IsDaem
         self.logger.info(f"PID: {os.getpid()}")
         self._base_url = f"http://{config['topas4_host']}:{config['topas4_port']}/{config['serial']}/v0/PublicApi"
         self._motor_index = config["motor_index"]
-        self.client.open(self.config["port"])
+        self.client.open(config["port"])
         self._http_session = self.client.session
         self._position_identifiers: dict[str, float] = {}
         self.tasks = TaskSet()

--- a/yaqd_lightcon/_lightcon_topas4_motor.py
+++ b/yaqd_lightcon/_lightcon_topas4_motor.py
@@ -1,24 +1,26 @@
+from __future__ import annotations
+
 import asyncio
 import pathlib
 import os
-from typing import Dict, Any, List
+from typing import Any
 
 from yaqd_core import IsHomeable, IsDiscrete, HasLimits, HasPosition, IsDaemon
 from ._aiohttp import TaskSet, Client
 
+
 class LightconTopas4Motor(IsHomeable, IsDiscrete, HasLimits, HasPosition, IsDaemon):
     _kind = "lightcon-topas4-motor"
-    __sessions = {}
+    client = Client
 
-    def __init__(self, name: str, config: Dict[str, Any], config_filepath: pathlib.Path):
+    def __init__(self, name: str, config: dict[str, Any], config_filepath: pathlib.Path):
         super().__init__(name, config, config_filepath)
         self.logger.info(f"PID: {os.getpid()}")
         self._base_url = f"http://{config['topas4_host']}:{config['topas4_port']}/{config['serial']}/v0/PublicApi"
         self._motor_index = config["motor_index"]
-        self.client = Client
         self.client.open(self.config["port"])
         self._http_session = self.client.session
-        self._position_identifiers: Dict[str, float] = {}
+        self._position_identifiers: dict[str, float] = {}
         self.tasks = TaskSet()
 
     async def update_state(self):
@@ -42,7 +44,7 @@ class LightconTopas4Motor(IsHomeable, IsDiscrete, HasLimits, HasPosition, IsDaem
                 offset = json["Affix"]
                 scale = json["Factor"]
 
-                self._position_identifiers: Dict[str, float] = {
+                self._position_identifiers: dict[str, float] = {
                     i["Name"]: i["Position"] / 8 / scale + offset for i in json["NamedPositions"]
                 }
 

--- a/yaqd_lightcon/_lightcon_topas4_motor.py
+++ b/yaqd_lightcon/_lightcon_topas4_motor.py
@@ -1,12 +1,11 @@
-from __future__ import annotations
-
 import asyncio
 import pathlib
 import os
 from typing import Any
 
 from yaqd_core import IsHomeable, IsDiscrete, HasLimits, HasPosition, IsDaemon
-from ._aiohttp import TaskSet, Client
+from ._aiohttp import Client
+from ._taskset import TaskSet
 
 
 class LightconTopas4Motor(IsHomeable, IsDiscrete, HasLimits, HasPosition, IsDaemon):

--- a/yaqd_lightcon/_lightcon_topas4_motor.py
+++ b/yaqd_lightcon/_lightcon_topas4_motor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import pathlib
 import os

--- a/yaqd_lightcon/_taskset.py
+++ b/yaqd_lightcon/_taskset.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import asyncio
+
+
+class TaskSet(set):
+    """container class for tasks to keep strong references"""
+
+    def add(self, task: asyncio.Task):
+        super().add(task)
+        task.add_done_callback(self.discard)
+
+    def add_coro(self, coro):
+        """create task and add to running loop"""
+        task = asyncio.get_running_loop().create_task(coro)
+        self.add(task)


### PR DESCRIPTION
All daemons ran their own session with the lightcon motors, but there is no need for that.  Now all daemons run out of the same session.  Session closes when no daemons are connected to the session.

This sounds like a small issue, but with ~tens of motors on each table, the memory saved is actually significant.

Tested on fs system.

* replaces daemon ClientSession instances with a single class
* adds daemon close method